### PR TITLE
Removing compilation of less files in a component

### DIFF
--- a/lib/gulpfile.js
+++ b/lib/gulpfile.js
@@ -173,18 +173,7 @@ function compile(modules) {
   const less = gulp.src(['components/**/*.less'])
     .pipe(through2.obj(function (file, encoding, next) {
       this.push(file.clone());
-      if (file.path.match(/\/style\/index\.less$/)) {
-        transformLess(file.path).then((css) => {
-          file.contents = new Buffer(css);
-          file.path = file.path.replace(/\.less$/, '.css');
-          this.push(file);
-          next();
-        }).catch((e) => {
-          console.error(e);
-        });
-      } else {
-        next();
-      }
+      next();
     }))
     .pipe(gulp.dest(modules === false ? esDir : libDir));
   const assets = gulp.src(['components/**/*.@(png|svg)']).pipe(gulp.dest(modules === false ? esDir : libDir));


### PR DESCRIPTION
Less files of a component will b ecompiles in the final package
we won't be importing compiles css files in our project